### PR TITLE
Fix display issue of fork URL in client gem README

### DIFF
--- a/semaphoria/README.md
+++ b/semaphoria/README.md
@@ -22,7 +22,7 @@ TODO: Write usage instructions here
 
 ## Contributing
 
-1. Fork it ( http://github.com/<my-github-username>/semaphoria/fork )
+1. Fork it ( http://github.com/my-github-username/semaphoria/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
The <> was throwing off the Markdown renderer
